### PR TITLE
Fix streamer2

### DIFF
--- a/src/streamer/jamstreamer.cpp
+++ b/src/streamer/jamstreamer.cpp
@@ -23,10 +23,11 @@ void CJamStreamer::OnStarted() {
         QObject::connect ( qproc, QOverload<int, QProcess::ExitStatus>::of( &QProcess::finished ), this, &CJamStreamer::onFinished );
         qproc->setStandardOutputFile ( QProcess::nullDevice() );
     }
-    QStringList argumentList = { "ffmpeg", "-loglevel", "fatal",
+    QStringList argumentList = { "-loglevel", "error",
                                  "-y", "-f", "s16le",
                                  "-ar", "48000", "-ac", "2",
-                                 "-i", "-", strStreamDest };
+                                 "-i", "-" };
+    argumentList += strStreamDest.split( QRegExp("\\s+") );
     // Note that program name is also repeated as first argument
     qproc->start ( "ffmpeg", argumentList );
 }

--- a/src/streamer/jamstreamer.cpp
+++ b/src/streamer/jamstreamer.cpp
@@ -20,7 +20,7 @@ void CJamStreamer::OnStarted() {
     {
         qproc = new QProcess;
         QObject::connect ( qproc, &QProcess::errorOccurred, this, &CJamStreamer::onError );
-        qproc->setStandardErrorFile ( "ffmpeg.stderr.txt" );
+        QObject::connect ( qproc, QOverload<int, QProcess::ExitStatus>::of( &QProcess::finished ), this, &CJamStreamer::onFinished );
         qproc->setStandardOutputFile ( QProcess::nullDevice() );
     }
     QStringList argumentList = { "ffmpeg", "-loglevel", "fatal",
@@ -28,7 +28,7 @@ void CJamStreamer::OnStarted() {
                                  "-ar", "48000", "-ac", "2",
                                  "-i", "-", strStreamDest };
     // Note that program name is also repeated as first argument
-    qproc->start ( "ffmpeg", argumentList, QIODevice::WriteOnly );
+    qproc->start ( "ffmpeg", argumentList );
 }
 
 void CJamStreamer::onError(QProcess::ProcessError error)
@@ -60,6 +60,12 @@ void CJamStreamer::onError(QProcess::ProcessError error)
     qWarning() << "QProcess Error: " << errDesc << "\n";
 }
 
+void CJamStreamer::onFinished( int exitCode, QProcess::ExitStatus exitStatus )
+{
+    Q_UNUSED ( exitStatus );
+    QByteArray stderr = qproc->readAllStandardError ();
+    qInfo() << "ffmpeg exited with exitCode" << exitCode << ", stderr:" << stderr;
+}
 
 void CJamStreamer::OnStopped() {
     qproc->closeWriteChannel ();

--- a/src/streamer/jamstreamer.h
+++ b/src/streamer/jamstreamer.h
@@ -18,6 +18,7 @@ public slots:
     void OnStopped();
 private slots:
     void onError(QProcess::ProcessError error);
+    void onFinished( int exitCode, QProcess::ExitStatus exitStatus );
 
 private:
     QString strStreamDest; // stream destination to pass to ffmpeg as output part of arguments


### PR DESCRIPTION
This PR attempts to fix the QProcess-based ffmpeg invocation:
- It adds proper logging on ffmpeg exits by adding a `::finished` handler and upping the ffmpeg loglevel so that something sane is output.
- It stops adding "ffmpeg" as the first argument as this seems to be done implicitly by `QProcess` (spotted using strace)
- It adds support for parsing space-delimited multiple arguments for ffmpeg. Otherwise, only a single argument would be supported and things like `--streamto "-f mp3 /tmp/foo"` would break.

Note: The crazy override for the ::finished handler is described here: https://doc.qt.io/qt-5/qprocess.html#finished

cc @npostavs @dingodoppelt